### PR TITLE
Genericization of the project to allow a template based out of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,14 @@ Minify the JavaScript bundle for production use
 npm run minify
 ```
 
+## Customization
+
+There are currently a few values that can be changed to customize the job board.
+```
+    DOMAIN_URL
+    HEADER_TITLE
+    JOB_LIST_TITLE
+    HOMEPAGE_TITLE
+```
+These can be found in `src/shared/settings.js`
+Edit `HEADER_TITLE` to change the title on top of the website or `JOB_LIST_TITLE` to modify the text on top of the jobs' list.

--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -2,10 +2,11 @@
 
 const React = require('react');
 const JobList = require('components/JobList');
+const settings = require('shared/settings');
 
 const Homepage = React.createClass({
   statics: {
-    title: 'Oklahoma Tech Jobs',
+    title: settings.HOMEPAGE_TITLE,
     fetchData(params) {
       return JobList.fetchData(params);
     }

--- a/src/components/JobList.js
+++ b/src/components/JobList.js
@@ -3,6 +3,7 @@
 const React = require('react');
 const JobListingRow = require('components/JobListingRow');
 const sdk = require('server/sdk');
+const settings = require('shared/settings');
 
 const JobList = React.createClass({
   statics: {
@@ -17,7 +18,7 @@ const JobList = React.createClass({
 
     return (
       <div className="job-list">
-        <h1>Oklahoma Tech Jobs</h1>
+        <h1>{settings.JOB_LIST_TITLE}</h1>
         <div className="panel panel-default">
           <div className="list-group">
             { jobs.length === 0 ? this._renderNoJobs() : undefined}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -20,6 +20,8 @@ const sharedUtils = require('shared/utils');
 const sdk = require('server/sdk');
 const auth = require('lib/auth');
 
+const settings = require('shared/settings');
+
 // Setup
 require('server/setup/mail-templates');
 
@@ -176,7 +178,8 @@ function renderComponentWithLayout(res, renderFunc, component, props = {}, layou
     title: component.title,
     js: component.js || [],
     css: component.css || [],
-    react_props: JSON.stringify(props)
+    react_props: JSON.stringify(props),
+    settings: settings,
   });
 }
 

--- a/src/shared/settings.js
+++ b/src/shared/settings.js
@@ -1,0 +1,8 @@
+const settings = {
+    "DOMAIN_URL": "localhost",
+    "HEADER_TITLE": "Job board",
+    "JOB_LIST_TITLE": "Jobs",
+    "HOMEPAGE_TITLE": "Index"
+};
+
+module.exports = settings;

--- a/views/emails/jobs-approve-after.ejs
+++ b/views/emails/jobs-approve-after.ejs
@@ -1,7 +1,7 @@
 
 <h1>Job Listing Approved!</h1>
-<h2><a href="https://jobs.techlahoma.org/jobs/<%- job.id %>"><%- job.title %></a></h2>
+<h2><a href="<%- settings.DOMAIN_URL %>/jobs/<%- job.id %>"><%- job.title %></a></h2>
 
-<p>Your job listing is now live on the Techlahoma jobs website!</p>
+<p>Your job listing is now live on the website!</p>
 
 <p>Your job listing will be live for <strong><%- process.env.JOBS_DAYS_TO_EXPIRE %> days</strong> from now.</p>

--- a/views/partials/layout/header.ejs
+++ b/views/partials/layout/header.ejs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title><%- title || 'Home' %> - Techlahoma Jobs</title>
+  <title><%- title || 'Home' %> - <%- settings.HEADER_TITLE %></title>
   <meta charset="utf-8" />
 
   <link rel="stylesheet" href="/css/bootstrap.min.css" />
@@ -16,7 +16,7 @@
   <div class="navbar navbar-default navbar-fixed-top">
     <div class="container">
       <div class="navbar-header pull-left">
-        <a href="/" target="_top" class="navbar-brand">Techlahoma Jobs</a>
+        <a href="/" target="_top" class="navbar-brand"><%- settings.HEADER_TITLE %></a>
       </div>
       <ul class="nav navbar-nav pull-right">
       <% if (user) { %>


### PR DESCRIPTION
Added `src/shared/settings.js` as a first step to allow users of the project to customize the job board a bit.

Default values:
![Screenshot_20190923_202131](https://user-images.githubusercontent.com/31956057/65451569-bd323180-de3f-11e9-8d78-0064281b08ca.png)
